### PR TITLE
Add sentence tokenization to process longer texts.

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,6 +3,9 @@ from flask_cors import CORS
 
 from bert import Ner
 
+import nltk.data
+sent_detector = nltk.data.load('tokenizers/punkt/english.pickle')
+
 app = Flask(__name__)
 CORS(app)
 
@@ -11,9 +14,22 @@ model = Ner("out_!x")
 @app.route("/predict",methods=['POST'])
 def predict():
     text = request.json["text"]
+    sentences = sent_detector.tokenize(text)
+
     try:
-        out = model.predict(text)
-        return jsonify({"result":out})
+        ner_tagged_sentences = []
+        for sentence in sentences:
+            if len(sentence) < 512:
+                tagged_sentence = model.predict(sentence)
+                ner_tagged_sentences.extend(tagged_sentence)
+            else:
+                chunks = [sentence[x:x+512] for x in range(0, len(sentence), 512)]
+                tagged_sentence = []
+                for chunk in chunks:
+                    ner_chunk = model.predict(chunk)
+                    tagged_sentence.extend(ner_chunk)
+                ner_tagged_sentences.extend(tagged_sentence)
+        return jsonify({"result":ner_tagged_sentences})
     except Exception as e:
         print(e)
         return jsonify({"result":"Model Failed"})


### PR DESCRIPTION
The supported sequence length of BERT is up to 512 tokens. Adding a simple sentence tokenization to API would enable users to process longer texts.